### PR TITLE
feat: add Claude Agent SDK hosting sample

### DIFF
--- a/primitives/README.md
+++ b/primitives/README.md
@@ -7,7 +7,7 @@ Building blocks for AI agents using Amazon Bedrock AgentCore.
 ```
 primitives/
 ├── runtime/                      # AgentCore Runtime samples
-│   ├── hosting-agent/            # Deploy agents (Strands, Vercel AI)
+│   ├── hosting-agent/            # Deploy agents (Strands, Vercel AI, Claude Agent SDK)
 │   ├── bidirectional-streaming/  # WebSocket communication
 │   └── async-agent/              # Long-running tasks
 ├── identity/                     # AgentCore Identity samples

--- a/primitives/runtime/README.md
+++ b/primitives/runtime/README.md
@@ -140,7 +140,7 @@ For OAuth setup, see the [AgentCore Identity documentation](https://docs.aws.ama
 
 ### [hosting-agent](./hosting-agent/)
 
-Deploy an AI agent that responds to prompts with tool use. Implementations for Strands Agents SDK and Vercel AI SDK.
+Deploy an AI agent that responds to prompts with tool use. Implementations for Strands Agents SDK, Vercel AI SDK, and Claude Agent SDK.
 
 ### [bidirectional-streaming](./bidirectional-streaming/)
 

--- a/primitives/runtime/hosting-agent/README.md
+++ b/primitives/runtime/hosting-agent/README.md
@@ -76,7 +76,43 @@ const app = new BedrockAgentCoreApp({
 
 ---
 
+### [Claude Agent SDK](./claude-agent/)
+
+Uses `@anthropic-ai/claude-agent-sdk` — model calls route through Amazon Bedrock via `CLAUDE_CODE_USE_BEDROCK=1`. Deployed via container image since the SDK spawns the Claude Code CLI as a subprocess.
+
+```typescript
+import { query } from '@anthropic-ai/claude-agent-sdk'
+import { BedrockAgentCoreApp } from 'bedrock-agentcore/runtime'
+
+const app = new BedrockAgentCoreApp({
+  invocationHandler: {
+    process: async function* (request, _context) {
+      const response = query({
+        prompt: request.prompt,
+        options: { systemPrompt: "You're a helpful assistant.", maxTurns: 5, allowedTools: [] },
+      })
+
+      for await (const message of response) {
+        if (message.type === 'assistant') {
+          for (const block of message.message.content) {
+            if (block.type === 'text') {
+              yield { event: 'message', data: { text: block.text } }
+            }
+          }
+        }
+      }
+    },
+  },
+})
+```
+
+→ [Full source](./claude-agent/src/agent.ts)
+
+---
+
 ## Quick Start
+
+For Strands or Vercel AI:
 
 ```bash
 cd strands  # or vercel-ai
@@ -85,6 +121,16 @@ npm install
 agentcore configure
 agentcore dev       # Run locally
 agentcore deploy    # Deploy to AgentCore
+```
+
+For Claude Agent SDK (container-based deployment):
+
+```bash
+cd claude-agent
+npm install
+npm run dev         # Run locally
+./build-image.sh    # Build container
+npm run deploy      # Deploy to AgentCore
 ```
 
 ## How It Works

--- a/primitives/runtime/hosting-agent/claude-agent/Dockerfile
+++ b/primitives/runtime/hosting-agent/claude-agent/Dockerfile
@@ -1,0 +1,36 @@
+# Amazon Bedrock AgentCore Runtime container for a Claude Agent SDK agent.
+#
+# Requirements (per AgentCore Runtime):
+#   - Platform: ARM64
+#   - Listens on 0.0.0.0:8080
+#   - Runs as non-root user
+#
+# The Claude Agent SDK spawns the Claude Code CLI as a subprocess, so it
+# must be installed globally in the container.
+
+FROM --platform=linux/arm64 public.ecr.aws/docker/library/node:20-slim AS builder
+
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY tsconfig.json agent.ts ./
+RUN npm run build
+
+FROM --platform=linux/arm64 public.ecr.aws/docker/library/node:20-slim
+
+WORKDIR /app
+
+RUN npm install -g @anthropic-ai/claude-code@latest
+
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package*.json ./
+
+RUN useradd -m -u 1001 bedrock_agentcore
+USER bedrock_agentcore
+
+ENV CLAUDE_CODE_USE_BEDROCK=1
+
+EXPOSE 8080
+
+CMD ["node", "--require", "@opentelemetry/auto-instrumentations-node/register", "dist/agent.js"]

--- a/primitives/runtime/hosting-agent/claude-agent/README.md
+++ b/primitives/runtime/hosting-agent/claude-agent/README.md
@@ -1,0 +1,139 @@
+# Hosting an Agent (Claude Agent SDK)
+
+Deploy a [Claude Agent SDK](https://docs.anthropic.com/en/docs/agents/claude-agent-sdk) agent to Amazon Bedrock AgentCore Runtime, with model calls routed through Amazon Bedrock.
+
+→ See [parent README](../README.md) for full context on hosting agents.
+
+## How It Works
+
+The Claude Agent SDK (`@anthropic-ai/claude-agent-sdk`) spawns the Claude Code CLI as a subprocess and drives an agent loop. Setting `CLAUDE_CODE_USE_BEDROCK=1` and `ANTHROPIC_MODEL=<bedrock inference profile ID>` routes every model call through Amazon Bedrock using the container's IAM role credentials — no Anthropic API key needed.
+
+Unlike the Strands and Vercel AI samples, this one ships a custom `Dockerfile` so the Claude Code CLI is available in the image. The `agentcore` CLI picks up the Dockerfile automatically during deployment.
+
+## Prerequisites
+
+- Node.js 20+
+- AWS credentials configured
+- Docker (or Podman/Finch) for local dev
+- [AgentCore Starter Toolkit](https://github.com/aws/bedrock-agentcore-starter-toolkit):
+
+```bash
+pip install bedrock-agentcore-starter-toolkit
+```
+
+## Implementation
+
+```typescript
+import { query } from '@anthropic-ai/claude-agent-sdk'
+import { BedrockAgentCoreApp } from 'bedrock-agentcore/runtime'
+import { z } from 'zod'
+
+const requestSchema = z.object({ prompt: z.string() })
+
+const app = new BedrockAgentCoreApp({
+  invocationHandler: {
+    requestSchema,
+    process: async function* (request, _context) {
+      const response = query({
+        prompt: request.prompt,
+        options: {
+          systemPrompt: "You're a helpful assistant.",
+          maxTurns: 5,
+          allowedTools: [],
+        },
+      })
+
+      for await (const message of response) {
+        if (message.type === 'assistant') {
+          for (const block of message.message.content) {
+            if (block.type === 'text') {
+              yield { event: 'message', data: { text: block.text } }
+            }
+          }
+        }
+      }
+    },
+  },
+})
+
+app.run()
+```
+
+→ [Full source](./agent.ts)
+
+## Quick Start
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Configure the agent (specify `agent.ts` as the entrypoint):
+
+```bash
+agentcore configure
+```
+
+Accept defaults for all prompts, except for memory—enter `s` to skip memory creation. The CLI detects the Dockerfile and uses container-based deployment.
+
+Set environment variables so the Claude Agent SDK routes through Bedrock:
+
+```bash
+agentcore configure env CLAUDE_CODE_USE_BEDROCK=1
+agentcore configure env ANTHROPIC_MODEL=us.anthropic.claude-sonnet-4-5-20250929-v1:0
+```
+
+## Local Development
+
+The Claude Code CLI subprocess needs AWS credentials and Bedrock access locally:
+
+```bash
+npm install -g @anthropic-ai/claude-code@latest
+
+export CLAUDE_CODE_USE_BEDROCK=1
+export ANTHROPIC_MODEL=us.anthropic.claude-sonnet-4-5-20250929-v1:0
+export AWS_REGION=us-east-1
+```
+
+Start the local dev server:
+
+```bash
+agentcore dev
+```
+
+Test with the CLI:
+
+```bash
+agentcore invoke --dev '{"prompt": "What is the capital of France?"}'
+```
+
+Or with curl:
+
+```bash
+curl -X POST http://localhost:8080/invocations \
+  -H "Content-Type: application/json" \
+  -H "Accept: text/event-stream" \
+  -H "x-amzn-bedrock-agentcore-runtime-session-id: test-123" \
+  -d '{"prompt": "What is the capital of France?"}'
+```
+
+## Deploy to AWS
+
+```bash
+agentcore deploy
+```
+
+AgentCore builds the ARM64 container in AWS CodeBuild, pushes it to ECR, and creates the Runtime. The execution role is granted Bedrock model invocation permissions automatically.
+
+## Test Deployed Agent
+
+```bash
+agentcore invoke '{"prompt": "What is the capital of France?"}'
+```
+
+## Clean Up
+
+```bash
+agentcore destroy
+```

--- a/primitives/runtime/hosting-agent/claude-agent/agent.ts
+++ b/primitives/runtime/hosting-agent/claude-agent/agent.ts
@@ -1,0 +1,45 @@
+/**
+ * Hosts a Claude Agent SDK agent on Amazon Bedrock AgentCore Runtime.
+ *
+ * The Claude Agent SDK (@anthropic-ai/claude-agent-sdk) spawns the Claude Code
+ * CLI under the hood. Model calls are routed through Amazon Bedrock when the
+ * environment variable CLAUDE_CODE_USE_BEDROCK=1 is set, using the model ID
+ * from ANTHROPIC_MODEL (a Bedrock cross-region inference profile).
+ */
+import { query } from '@anthropic-ai/claude-agent-sdk'
+import { BedrockAgentCoreApp } from 'bedrock-agentcore/runtime'
+import { z } from 'zod'
+
+const requestSchema = z.object({
+  prompt: z.string(),
+})
+
+const SYSTEM_PROMPT = "You're a helpful assistant. Answer the user's question directly and concisely."
+
+const app = new BedrockAgentCoreApp({
+  invocationHandler: {
+    requestSchema,
+    process: async function* (request, _context) {
+      const response = query({
+        prompt: request.prompt,
+        options: {
+          systemPrompt: SYSTEM_PROMPT,
+          maxTurns: 5,
+          allowedTools: [],
+        },
+      })
+
+      for await (const message of response) {
+        if (message.type === 'assistant') {
+          for (const block of message.message.content) {
+            if (block.type === 'text') {
+              yield { event: 'message', data: { text: block.text } }
+            }
+          }
+        }
+      }
+    },
+  },
+})
+
+app.run()

--- a/primitives/runtime/hosting-agent/claude-agent/package.json
+++ b/primitives/runtime/hosting-agent/claude-agent/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "hosting-agent-claude-agent",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "build": "./node_modules/typescript/bin/tsc",
+    "dev": "tsx watch agent.ts",
+    "start": "node dist/agent.js"
+  },
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.1.0",
+    "@anthropic-ai/claude-code": "^2.0.0",
+    "@opentelemetry/auto-instrumentations-node": "^0.68.0",
+    "bedrock-agentcore": "^0.2.0",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/primitives/runtime/hosting-agent/claude-agent/tsconfig.json
+++ b/primitives/runtime/hosting-agent/claude-agent/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["agent.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Description

Adds a new hosting-agent sample demonstrating how to deploy an agent built with [Claude Agent SDK](https://code.claude.com/docs/en/agent-sdk/overview) agent to AgentCore Runtime, with model calls routed through Amazon Bedrock

## Type of Change

- [x] New example

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the existing style patterns
- [x] I have run `npm run validate` locally and it passes
- [x] I have added/updated documentation as needed (sample README + parent READMEs at every level)
- [x] I have tested my changes locally

## Testing

Deployed end-to-end with `agentcore configure` → `agentcore deploy` → `agentcore invoke` in us-east-1 against Claude Sonnet 4.5 on Bedrock. Verified both a simple prompt ("What is the capital of France?") and a more open-ended one, and confirmed streaming events arrive correctly.
