### PR TITLE
Document invocation input validation in TypeScript samples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,7 +150,7 @@ Examples include customer support agents, data analyzers, and other practical ap
 
 - Never hardcode credentials — use environment variables or AWS SDK credential chain
 - Demonstrate proper error handling in production-ready examples
-- Use secure defaults (e.g., input validation with Zod schemas)
+- Use secure defaults (e.g., string input validation with Zod schemas)
 - Follow AWS security best practices
 
 ## Testing and Validation

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ const app = new BedrockAgentCoreApp({
 app.run()
 ```
 
+Use `requestSchema` to validate agent entrypoint input. Keep text prompts defined as `z.string()` and pass only prompt
+text to the agent.
+
 → [Runtime examples](./primitives/runtime/)
 
 ### Tools

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -147,7 +147,7 @@ npm outdated
 ## Built-in Security Features
 
 - **AWS SDK Integration**: Leverages AWS SDK's credential provider chain and request signing
-- **Input Validation**: Zod schemas validate all tool inputs at runtime
+- **Input Validation**: Zod schemas validate tool inputs and keep runtime prompts typed as strings
 - **Session Isolation**: Each CodeInterpreter/Browser session is isolated in AWS infrastructure
 - **HTTPS Only**: All communication with AWS services uses HTTPS
 - **No Credential Storage**: SDK never persists credentials to disk

--- a/primitives/runtime/README.md
+++ b/primitives/runtime/README.md
@@ -58,6 +58,9 @@ const app = new BedrockAgentCoreApp({
 app.run() // Starts HTTP server on port 8080
 ```
 
+Validate invocation payloads before forwarding them to an agent. Keep text prompts defined as `z.string()` and pass
+only prompt text to the agent.
+
 The generator function (`async function*`) enables streaming — each `yield` sends an event to the client immediately.
 
 ## The AgentCore Protocol

--- a/primitives/runtime/hosting-agent/README.md
+++ b/primitives/runtime/hosting-agent/README.md
@@ -18,6 +18,7 @@ Uses `@strands-agents/sdk` with native Bedrock integration.
 ```typescript
 import { Agent, BedrockModel, tool } from '@strands-agents/sdk'
 import { BedrockAgentCoreApp } from 'bedrock-agentcore/runtime'
+import { z } from 'zod'
 
 const agent = new Agent({
   model: new BedrockModel({
@@ -29,6 +30,7 @@ const agent = new Agent({
 
 const app = new BedrockAgentCoreApp({
   invocationHandler: {
+    requestSchema: z.object({ prompt: z.string() }),
     process: async function* (request, _context) {
       for await (const event of agent.stream(request.prompt)) {
         if (event.type === 'modelContentBlockDeltaEvent' && event.delta?.type === 'textDelta') {
@@ -52,6 +54,7 @@ Uses `ai` SDK with `ToolLoopAgent` for agentic workflows.
 import { ToolLoopAgent, tool } from 'ai'
 import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock'
 import { BedrockAgentCoreApp } from 'bedrock-agentcore/runtime'
+import { z } from 'zod'
 
 const bedrock = createAmazonBedrock({ region: 'us-east-1' })
 
@@ -62,6 +65,7 @@ const agent = new ToolLoopAgent({
 
 const app = new BedrockAgentCoreApp({
   invocationHandler: {
+    requestSchema: z.object({ prompt: z.string() }),
     process: async function* (request, _context) {
       const stream = await agent.stream({ prompt: request.prompt })
       for await (const chunk of stream.textStream) {
@@ -75,6 +79,11 @@ const app = new BedrockAgentCoreApp({
 → [Full source](./vercel-ai/agent.ts)
 
 ---
+
+## Input Validation
+
+Validate invocation payloads before forwarding them to an agent. Keep the Zod string schema when adapting these
+samples so prompts stay typed as strings.
 
 ## Quick Start
 

--- a/primitives/runtime/hosting-agent/strands/README.md
+++ b/primitives/runtime/hosting-agent/strands/README.md
@@ -69,6 +69,9 @@ const app = new BedrockAgentCoreApp({
 app.run()
 ```
 
+The Zod request schema validates entrypoint input. Keep prompts typed as strings and pass only prompt text to
+Strands.
+
 → [Full source](./agent.ts)
 
 ## Quick Start

--- a/primitives/runtime/hosting-agent/vercel-ai/README.md
+++ b/primitives/runtime/hosting-agent/vercel-ai/README.md
@@ -67,6 +67,9 @@ const app = new BedrockAgentCoreApp({
 app.run()
 ```
 
+The Zod request schema validates entrypoint input. Keep prompts typed as strings and pass only prompt text to the
+agent.
+
 → [Full source](./agent.ts)
 
 ## Quick Start


### PR DESCRIPTION
## What

Document input validation across the TypeScript sample READMEs and add `requestSchema` to the hosting-agent snippets.

- README / SECURITY.md / AGENTS.md and runtime sample READMEs note to keep prompts typed as strings and pass only prompt text to the agent.
- Strands and Vercel AI hosting-agent snippets show a `z.object({ prompt: z.string() })` request schema.

## Testing

Docs and sample-snippet changes only.